### PR TITLE
Add RSpec paths

### DIFF
--- a/lib/manageiq/ui.rb
+++ b/lib/manageiq/ui.rb
@@ -2,6 +2,24 @@ require "manageiq/ui/engine"
 
 module Manageiq
   module Ui
-    # Your code goes here...
+    def self.root
+      Engine.root
+    end
+
+    def self.spec_root
+      root.join('spec')
+    end
+
+    def self.rspec_paths
+      dirs = [
+        spec_root.join('controllers'),
+        spec_root.join('helpers'),
+        spec_root.join('lib'),
+        spec_root.join('presenters'),
+        spec_root.join('views')
+      ].map{ |d| d.join('**', '*_spec.rb') }
+
+      FileList.new(dirs)
+    end
   end
 end

--- a/lib/manageiq/ui/engine.rb
+++ b/lib/manageiq/ui/engine.rb
@@ -3,8 +3,8 @@ require 'patternfly-sass'
 module Manageiq
   module Ui
     class Engine < ::Rails::Engine
-      config.autoload_paths << File.expand_path(File.join(root, 'app', 'controllers', 'mixins'), __FILE__)
-      config.autoload_paths << File.expand_path(File.join(root, 'lib'), __FILE__)
+      config.autoload_paths << root.join('app', 'controllers', 'mixins')
+      config.autoload_paths << root.join('lib')
     end
   end
 end

--- a/spec/presenters/tree_builder_report_saved_reports_spec.rb
+++ b/spec/presenters/tree_builder_report_saved_reports_spec.rb
@@ -1,4 +1,4 @@
-require "helpers/report_helper_spec"
+require Manageiq::Ui.spec_root.join("helpers/report_helper_spec.rb")
 
 describe TreeBuilderReportSavedReports do
   include CompressedIds


### PR DESCRIPTION
This adds path methods to aid in running specs from the core code base.

The idea is to create a UI suite that can be run in parallel, CI, etc.